### PR TITLE
Add config for port, use correct cursor in enumerate, remove undeclared data_sample

### DIFF
--- a/pgsql_big_dedupe_example/pgsql_big_dedupe_example_init_db.py
+++ b/pgsql_big_dedupe_example/pgsql_big_dedupe_example_init_db.py
@@ -75,7 +75,8 @@ if not db_conf:
 conn = psycopg2.connect(database=db_conf['NAME'],
                         user=db_conf['USER'],
                         password=db_conf['PASSWORD'],
-                        host=db_conf['HOST'])
+                        host=db_conf['HOST'],
+                        port=db_conf['PORT'])
 
 c = conn.cursor()
 


### PR DESCRIPTION
I noticed a few bugs in the pgsql_big_dedupe_fixes example that prevented it from running. Also, I'm running my local testing postgres instance on a non-standard port so added the ability to configure that.