### PR TITLE
Update call to dedupe.blocker.index in pgsql_big_dedupe_example for dedupe v0.8.0.1.7.

### DIFF
--- a/pgsql_big_dedupe_example/pgsql_big_dedupe_example.py
+++ b/pgsql_big_dedupe_example/pgsql_big_dedupe_example.py
@@ -74,13 +74,6 @@ con = psycopg2.connect(database=db_conf['NAME'],
 
 c = con.cursor()
 
-con2 = psycopg2.connect(database=db_conf['NAME'],
-                        user=db_conf['USER'],
-                        password=db_conf['PASSWORD'],
-                        host=db_conf['HOST'],
-                        port=db_conf['PORT'])
-
-
 # We'll be using variations on this following select statement to pull
 # in campaign donor info.
 #
@@ -195,9 +188,9 @@ c.execute("CREATE TABLE blocking_map "
 print 'creating inverted index'
 
 for field in deduper.blocker.index_fields:
-    c2 = con2.cursor('c2')
+    c2 = con.cursor('c2')
     c2.execute("SELECT DISTINCT %s FROM processed_donors" % field)
-    field_data = (row for row in c2)
+    field_data = set(row[field] for row in c2)
     deduper.blocker.index(field_data, field)
     c2.close()
 

--- a/pgsql_big_dedupe_example/pgsql_big_dedupe_example.py
+++ b/pgsql_big_dedupe_example/pgsql_big_dedupe_example.py
@@ -190,7 +190,7 @@ print 'creating inverted index'
 for field in deduper.blocker.index_fields:
     c2 = con.cursor('c2')
     c2.execute("SELECT DISTINCT %s FROM processed_donors" % field)
-    field_data = set(row[field] for row in c2)
+    field_data = (row[field] for row in c2)
     deduper.blocker.index(field_data, field)
     c2.close()
 


### PR DESCRIPTION
As it stands, pgsql_big_dedupe_example fails when run with dedupe v0.8.0.1.7 (the latest currently available on pypi). Running `python pgsql_big_dedupe_example.py` generates the following output:

```
INFO:root:Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
INFO:root:Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
reading from  pgsql_big_dedupe_example_settings
blocking...
creating blocking_map database
creating inverted index
Traceback (most recent call last):
  File "pgsql_big_dedupe_example.py", line 177, in <module>
    deduper.blocker.index(field_data, field)
  File "/home/ec2-user/dedupe-examples/pgsql_big_dedupe_example/local/lib/python2.7/site-packages/dedupe/blocking.py", line 74, in index
    index.index(preprocess(doc))
  File "/home/ec2-user/dedupe-examples/pgsql_big_dedupe_example/local/lib/python2.7/site-packages/dedupe/predicates.py", line 161, in preprocess
    return tuple(ngrams(doc.replace(' ', ''), 2))
AttributeError: 'tuple' object has no attribute 'replace'
```

This PR fixes this issue by bringing the call to `deduper.blocker.index` up to date with the [current documentation for dedupe v0.8](http://dedupe.readthedocs.org/en/latest/API-documentation.html): 

> **blocker.index(*field_data*, *field*)**
> Indexes the data from a field for use in a index predicate.

> **Parameters**:	
> **field data** (set) – The unique field values that appear in your data.
> **field** (string) – The name of the field
```python
> for field in deduper.blocker.index_fields :
>     field_data = set(record[field] for record in data)
>     deduper.index(field_data, field)
````

